### PR TITLE
chore(factory): use precomputed hash for 'secret'

### DIFF
--- a/database/factory.js
+++ b/database/factory.js
@@ -25,6 +25,6 @@ Factory.blueprint('App/Model/User', (fake) => {
   return {
     username: fake.username(),
     email: fake.email(),
-    password: fake.password()
+    password: '$2a$10$rZdHPJLfrnSQ6/S8GgzteefKzihwvbGhuWl7HWaQeKu2FeQ6CMejS'
   }
 })


### PR DESCRIPTION
Use a precomputed hash of the word "secret" instead of random generated password.
