### PR TITLE
Update entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adonis-app",
   "version": "3.1.0",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "dev": "nodemon --watch app --watch bootstrap --watch config --watch .env -x \"node --harmony_proxies\" server.js",
     "start": "node --harmony_proxies server.js",


### PR DESCRIPTION
Utilities like `nodemon` throw an error because `index.js` is actually not the entry for `app`. `server.js` is.