### PR TITLE
Add support for ace command on windows

### DIFF
--- a/ace.bat
+++ b/ace.bat
@@ -1,0 +1,1 @@
+node ace %*


### PR DESCRIPTION
It will allow executing the ace commands on windows as in the documentation

instead of
./ace "Command"

you can use

ace "Command"
