### PR TITLE
chore(scripts): rename the script to be more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.2.0",
   "main": "server.js",
   "scripts": {
+    "start": "echo \"\\033[31mWARN: 'start' will be depreciated soon. Instead use 'npm run serve'\" && npm run serve",
+    "dev": "echo \"\\033[31mWARN: 'dev' will be depreciated soon. Instead use 'npm run serve:dev'\" && npm run serve:dev",
     "serve:dev": "nodemon --watch app --watch bootstrap --watch config --watch .env -x node server.js",
     "serve": "node server.js",
     "lint": "standard"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.2.0",
   "main": "server.js",
   "scripts": {
-    "dev": "nodemon --watch app --watch bootstrap --watch config --watch .env -x node server.js",
-    "start": "node server.js",
+    "serve:dev": "nodemon --watch app --watch bootstrap --watch config --watch .env -x node server.js",
+    "serve": "node server.js",
     "lint": "standard"
   },
   "author": "",


### PR DESCRIPTION
The current script name (`dev` & `start`) are too generic and can conflict if someone is using `npm` as a task launcher. Renaming them to `serve` & `serve:dev` is better in my opinion.