### PR TITLE
fix(session): write a note for redis driver

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -35,6 +35,9 @@ module.exports = {
   | Define session life in minutes. Session will be destroyed after defined
   | minutes of inactivity.
   |
+  | Note: If you are using Redis to store sessions you should define
+  | session life in seconds.
+  |
   */
   age: 120,
 


### PR DESCRIPTION
Redis use seconds instead of minutes to set an expiration time.

Closes: https://github.com/adonisjs/adonis-framework/issues/459