### PR TITLE
Add uid and password to personal api authenticator

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -85,7 +85,9 @@ module.exports = {
   api: {
     serializer: 'Lucid',
     model: 'App/Model/Token',
-    scheme: 'api'
+    scheme: 'api',
+    uid: 'email',
+    password: 'password'
   }
 
 }


### PR DESCRIPTION
If userid or password aren't defined, the SQL query of auth.attempt will always have undefined as values.