### PR TITLE
SQLite should reference the filename from the .env file instead of development.sqlite

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -30,7 +30,7 @@ module.exports = {
   sqlite: {
     client: 'sqlite3',
     connection: {
-      filename: Helpers.databasePath('development.sqlite')
+      filename: Helpers.databasePath(`${Env.get('DB_DATABASE', 'adonis')}.sqlite`)
     },
     useNullAsDefault: true
   },


### PR DESCRIPTION
When running tests you should be able to use a seperate database file. Currently it always uses the development.sqlite file.