### PR TITLE
Set default charset for MySQL as UTF8

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -53,7 +53,7 @@ module.exports = {
       user: Env.get('DB_USER', 'root'),
       password: Env.get('DB_PASSWORD', ''),
       database: Env.get('DB_DATABASE', 'adonis'),
-      charset: Env.get('DB_CHARSET', 'utf8')
+      charset: Env.get('DB_CHARSET', 'utf8mb4')
     }
   },
 

--- a/config/database.js
+++ b/config/database.js
@@ -52,7 +52,8 @@ module.exports = {
       port: Env.get('DB_PORT', ''),
       user: Env.get('DB_USER', 'root'),
       password: Env.get('DB_PASSWORD', ''),
-      database: Env.get('DB_DATABASE', 'adonis')
+      database: Env.get('DB_DATABASE', 'adonis'),
+      charset: Env.get('DB_CHARSET', 'utf8')
     }
   },
 


### PR DESCRIPTION
I think it is pretty common to have utf8 connection by default. Not sure about other databases, maybe we should provide charset for all of them.