### PR TITLE
Added APP_NAME and NODE_ENV to app.js config file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 HOST=localhost
 PORT=3333
 APP_KEY=
+APP_NAME=AdonisJs
 NODE_ENV=development
 CACHE_VIEWS=false
 SESSION_DRIVER=cookie

--- a/config/app.js
+++ b/config/app.js
@@ -9,9 +9,9 @@ module.exports = {
   | Application Name
   |--------------------------------------------------------------------------
   |
-  | This value is the name of your application. This value is used when the
-  | framework needs to place the application's name in a notification or
-  | any other location as required by the application or its packages.
+  | This value is the name of your application and can used when you
+  | need to place the application's name in a email, view or
+  | other location.
   |
   */
 

--- a/config/app.js
+++ b/config/app.js
@@ -3,6 +3,32 @@
 const Env = use('Env')
 
 module.exports = {
+  
+  /*
+  |--------------------------------------------------------------------------
+  | Application Name
+  |--------------------------------------------------------------------------
+  |
+  | This value is the name of your application. This value is used when the
+  | framework needs to place the application's name in a notification or
+  | any other location as required by the application or its packages.
+  |
+  */
+
+  name: Env.get('APP_NAME', 'AdonisJs'),
+
+  /*
+  |--------------------------------------------------------------------------
+  | Application Environment
+  |--------------------------------------------------------------------------
+  |
+  | This value determines the "environment" your application is currently
+  | running in. This may determine how you prefer to configure various
+  | services your application utilizes. Set this in your ".env" file.
+  |
+  */
+
+  env: Env.get('NODE_ENV', 'production'),
 
   /*
   |--------------------------------------------------------------------------

--- a/config/app.js
+++ b/config/app.js
@@ -19,19 +19,6 @@ module.exports = {
 
   /*
   |--------------------------------------------------------------------------
-  | Application Environment
-  |--------------------------------------------------------------------------
-  |
-  | This value determines the "environment" your application is currently
-  | running in. This may determine how you prefer to configure various
-  | services your application utilizes. Set this in your ".env" file.
-  |
-  */
-
-  env: Env.get('NODE_ENV', 'production'),
-
-  /*
-  |--------------------------------------------------------------------------
   | App Key
   |--------------------------------------------------------------------------
   |


### PR DESCRIPTION
Similar to Laravel, I've added APP_NAME and NODE_ENV to the app.js config file.

Including APP_NAME, allows an easy way to have the name of an app consistent throughout the app, rather than having to hard code it in.

NODE_ENV removes the need to potentially `use` both `Env` and `Config` and condenses it down into just `Config`. A niche use case, but a use case none the less!

Any problems, or suggestions, I'm all ears!

Thanks again for the great framework! 💯 